### PR TITLE
Refactor configuration for path management and remove runtime setup

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,17 @@
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+# Base directory for all outputs and data. Defaults to current working directory.
+BASE_DIR = Path(os.getenv("NFL_BOT_BASE_DIR", Path.cwd()))
+
+# Where to store data outputs
+DATA_OUT = Path(os.getenv("NFL_BOT_DATA_DIR", BASE_DIR / "data"))
+DATA_OUT.mkdir(parents=True, exist_ok=True)
+
+# .env path for credentials
+ENV_PATH = Path(os.getenv("NFL_BOT_ENV_PATH", BASE_DIR / ".env"))
+if ENV_PATH.exists():
+    load_dotenv(ENV_PATH)
+
+__all__ = ["BASE_DIR", "DATA_OUT", "ENV_PATH"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pandas
+numpy
+requests
+python-dotenv
+duckdb
+pyarrow
+tzdata
+openai
+nfl_data_py==0.3.1


### PR DESCRIPTION
## Summary
- Extract Google Drive and path handling into new `config` module with environment-driven defaults
- Remove inline dependency installation and drive mounting from runtime script
- Update starter script to import configuration and use resolved data directories
- Add `requirements.txt` for installing project dependencies

## Testing
- `python -m py_compile config.py nfl_bot_openmeteo_starter.py`

------
https://chatgpt.com/codex/tasks/task_e_68b75e383ecc8330b16d45485d13eb7d