### PR TITLE
Add HTTP utility with retries and integrate

### DIFF
--- a/nfl_bot/odds.py
+++ b/nfl_bot/odds.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 
 from typing import Optional, Tuple
 import os
+import logging
+
 import requests
 import pandas as pd
 
 from . import FULL_TO_CODE
+from .utils import http
 
 
 def call_the_odds_api_odds(
@@ -37,8 +40,12 @@ def call_the_odds_api_odds(
     if bookmakers:
         params["bookmakers"] = bookmakers
 
-    r = requests.get(url, params=params, timeout=timeout)
-    r.raise_for_status()
+    try:
+        r = http.get(url, params=params, timeout=timeout)
+    except requests.RequestException as exc:
+        logging.error("The Odds API request failed: %s", exc)
+        raise RuntimeError("Failed to fetch odds data") from exc
+
     headers = {
         "x-requests-remaining": r.headers.get("x-requests-remaining"),
         "x-requests-used": r.headers.get("x-requests-used"),

--- a/nfl_bot/utils/http.py
+++ b/nfl_bot/utils/http.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Optional, Dict, Any
+
+import requests
+
+
+def get(
+    url: str,
+    params: Optional[Dict[str, Any]] = None,
+    timeout: int = 30,
+    max_retries: int = 3,
+    backoff_factor: float = 1.0,
+) -> requests.Response:
+    """Perform a GET request with exponential backoff.
+
+    Args:
+        url: The URL to request.
+        params: Query parameters.
+        timeout: Request timeout in seconds.
+        max_retries: Maximum number of attempts.
+        backoff_factor: Base time to wait between retries in seconds.
+
+    Returns:
+        The ``requests.Response`` object.
+
+    Raises:
+        requests.RequestException: Propagated if the request ultimately fails.
+    """
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = requests.get(url, params=params, timeout=timeout)
+            response.raise_for_status()
+            return response
+        except requests.RequestException as exc:
+            wait = backoff_factor * (2 ** (attempt - 1))
+            logging.warning(
+                "GET request failed (%s); retrying in %.1fs (%d/%d)",
+                exc,
+                wait,
+                attempt,
+                max_retries,
+            )
+            if attempt == max_retries:
+                logging.error(
+                    "GET request to %s failed after %d attempts", url, max_retries
+                )
+                raise
+            time.sleep(wait)

--- a/nfl_bot/weather.py
+++ b/nfl_bot/weather.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from typing import Optional
+import logging
+
 import pandas as pd
 import requests
 
 from . import STADIUM_COORDS
+from .utils import http
 
 
 def om_forecast_near_kickoff(
@@ -26,10 +29,11 @@ def om_forecast_near_kickoff(
         "wind_speed_unit": "mph",
         "timezone": "auto",
     }
-    r = requests.get(base, params=params, timeout=timeout)
-    if r.status_code != 200:
-        print("Open-Meteo error:", r.status_code, r.text[:160])
-        return None
+    try:
+        r = http.get(base, params=params, timeout=timeout)
+    except requests.RequestException as exc:
+        logging.error("Open-Meteo request failed: %s", exc)
+        raise RuntimeError("Failed to fetch Open-Meteo forecast") from exc
     js = r.json() or {}
     hourly = js.get("hourly") or {}
     times = hourly.get("time") or []


### PR DESCRIPTION
## Summary
- add `utils.http.get` helper for retrying requests with exponential backoff
- use retrying HTTP client in weather and odds API helpers
- log failures and raise meaningful exceptions

## Testing
- `python -m py_compile nfl_bot/utils/http.py nfl_bot/weather.py nfl_bot/odds.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7758453b08330bb6cb6e736265d48