### PR TITLE
Add inactives data step to game-day pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # Testing
+
 Test
+
+## Inactives data
+
+The game-day pipeline now attempts to merge an **inactives** table into the
+game bundle. Each record should include the following columns:
+
+* `team` – team abbreviation
+* `player_name` – full name of the player
+* `status` – roster designation (e.g. `INACTIVE`)
+* `reason` – optional description
+* `game_id` – identifier matching the schedule table
+
+`fetch_inactives(kickoff_ts)` currently returns an empty table as a placeholder
+until a real data source is integrated. If the automated fetch fails on game
+day, create a CSV with the columns above and load it manually before calling
+`read_inactives`.

--- a/nfl_bot/data.py
+++ b/nfl_bot/data.py
@@ -12,6 +12,7 @@ from zoneinfo import ZoneInfo
 from . import TEAM_CODE_TO_FULL, FULL_TO_CODE, STADIUM_COORDS
 from .odds import call_the_odds_api_odds, flatten_odds_events, map_events_to_codes
 from .weather import open_meteo_for_game
+from .inactives import read_inactives
 
 
 def _concat_per_year_safely(import_fn, years: List[int], label: str) -> pd.DataFrame:
@@ -135,6 +136,7 @@ def get_week_bundle(season: int, week: int, years_back: int = 3, fd_only_fetch: 
         "odds_headers": headers,
         "weather_by_game": pd.DataFrame(weather_rows),
     }
+    bundle = read_inactives(bundle)
     return bundle
 
 

--- a/nfl_bot/inactives.py
+++ b/nfl_bot/inactives.py
@@ -1,0 +1,38 @@
+"""Inactives data utilities."""
+from __future__ import annotations
+
+from typing import Dict, Any
+import pandas as pd
+
+
+def fetch_inactives(kickoff_ts: pd.Timestamp) -> pd.DataFrame:
+    """Fetch the list of inactive players for a given kickoff time.
+
+    This is currently a placeholder that returns an empty frame until a real
+    data source is integrated.
+    """
+    cols = ["team", "player_name", "status", "reason"]
+    return pd.DataFrame(columns=cols)
+
+
+def read_inactives(bundle: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge inactives data into the provided game bundle."""
+    schedule = bundle.get("schedule", pd.DataFrame())
+    rows = []
+    if not schedule.empty:
+        for _, row in schedule.iterrows():
+            kdt = row.get("kickoff")
+            gid = row.get("game_id")
+            df = fetch_inactives(kdt)
+            df = df.copy()
+            df["game_id"] = gid
+            rows.append(df)
+    bundle["inactives"] = (
+        pd.concat(rows, ignore_index=True)
+        if rows
+        else pd.DataFrame(columns=["team", "player_name", "status", "reason", "game_id"])
+    )
+    return bundle
+
+
+__all__ = ["fetch_inactives", "read_inactives"]


### PR DESCRIPTION
## Summary
- add placeholder inactives fetcher and merge helper
- include inactives step when building weekly bundle
- document inactives data format and manual fallback

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7769b31e08330b33af78f72b25f67