### PR TITLE
Add weather condition flags and expose them in LLM contexts

### DIFF
--- a/nfl_bot/features.py
+++ b/nfl_bot/features.py
@@ -14,6 +14,7 @@ import nfl_data_py as nfl
 from . import TEAM_CODE_TO_FULL
 from config import DATA_OUT
 from .data import _concat_per_year_safely
+from .weather import weather_flags
 
 PREFERRED_BOOKS = (
     "fanduel",
@@ -96,6 +97,18 @@ def expand_weather(bundle: Dict[str, Any]) -> pd.DataFrame:
     w = bundle["weather_by_game"].copy()
     for k in ["temp_f", "wind_mph", "precip_prob_pct", "time_near_kickoff", "lat", "lon"]:
         w[f"wx_{k}"] = w["weather"].apply(lambda d: d.get(k) if isinstance(d, dict) else None)
+
+    flags = weather_flags(
+        w[["wx_temp_f", "wx_wind_mph", "wx_precip_prob_pct"]].rename(
+            columns={
+                "wx_temp_f": "temp_f",
+                "wx_wind_mph": "wind_mph",
+                "wx_precip_prob_pct": "precip_prob_pct",
+            }
+        )
+    )
+    for c in ["wind_15_plus", "precip_50_plus", "temp_below_32"]:
+        w[f"wx_{c}"] = flags[c]
     return w
 
 

--- a/nfl_bot/llm.py
+++ b/nfl_bot/llm.py
@@ -26,7 +26,16 @@ def build_game_packets(bundle: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Merge implied totals, weather, coach & ref context into JSON packets per game."""
     imp = build_implied_totals(bundle, strict_fanduel=False)
     wx = expand_weather(bundle)[
-        ["home_team", "kickoff", "wx_temp_f", "wx_wind_mph", "wx_precip_prob_pct"]
+        [
+            "home_team",
+            "kickoff",
+            "wx_temp_f",
+            "wx_wind_mph",
+            "wx_precip_prob_pct",
+            "wx_wind_15_plus",
+            "wx_precip_50_plus",
+            "wx_temp_below_32",
+        ]
     ].rename(columns={"home_team": "home_code"})
     coach = bundle.get("coach_ctx", pd.DataFrame())
     refc = bundle.get("ref_ctx", pd.DataFrame())
@@ -129,6 +138,21 @@ def build_game_packets(bundle: Dict[str, Any]) -> List[Dict[str, Any]]:
                     "temp_f": _safe(r.get("wx_temp_f")),
                     "wind_mph": _safe(r.get("wx_wind_mph")),
                     "precip_prob_pct": _safe(r.get("wx_precip_prob_pct")),
+                    "wind_15_plus": (
+                        bool(r.get("wx_wind_15_plus"))
+                        if pd.notna(r.get("wx_wind_15_plus"))
+                        else None
+                    ),
+                    "precip_50_plus": (
+                        bool(r.get("wx_precip_50_plus"))
+                        if pd.notna(r.get("wx_precip_50_plus"))
+                        else None
+                    ),
+                    "temp_below_32": (
+                        bool(r.get("wx_temp_below_32"))
+                        if pd.notna(r.get("wx_temp_below_32"))
+                        else None
+                    ),
                 },
                 "referee": {
                     "name": r.get("ref_name"),
@@ -273,7 +297,16 @@ def _limit_context_rows(df: pd.DataFrame, n: int = 8) -> pd.DataFrame:
 def build_qa_context(bundle: dict, question: str) -> dict:
     imp = build_implied_totals(bundle, strict_fanduel=False)
     wx = expand_weather(bundle)[
-        ["home_team", "kickoff", "wx_temp_f", "wx_wind_mph", "wx_precip_prob_pct"]
+        [
+            "home_team",
+            "kickoff",
+            "wx_temp_f",
+            "wx_wind_mph",
+            "wx_precip_prob_pct",
+            "wx_wind_15_plus",
+            "wx_precip_50_plus",
+            "wx_temp_below_32",
+        ]
     ]
     coach = bundle.get("coach_ctx", pd.DataFrame())
     refc = bundle.get("ref_ctx", pd.DataFrame())
@@ -341,6 +374,9 @@ def build_qa_context(bundle: dict, question: str) -> dict:
             "wx_temp_f",
             "wx_wind_mph",
             "wx_precip_prob_pct",
+            "wx_wind_15_plus",
+            "wx_precip_50_plus",
+            "wx_temp_below_32",
             "home_coach",
             "away_coach",
             "neutral_early_down_pass_rate_last4_home",

--- a/nfl_bot/weather.py
+++ b/nfl_bot/weather.py
@@ -70,4 +70,41 @@ def open_meteo_for_game(home_code: str, kickoff_ts: Optional[pd.Timestamp]) -> O
     return om_forecast_near_kickoff(lat, lon, kickoff_ts)
 
 
-__all__ = ["om_forecast_near_kickoff", "open_meteo_for_game"]
+def weather_flags(df: pd.DataFrame) -> pd.DataFrame:
+    """Add simple boolean weather flags to a DataFrame.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame with columns ``temp_f``, ``wind_mph`` and ``precip_prob_pct``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of ``df`` with boolean columns:
+
+        * ``wind_15_plus`` – wind speed at or above 15 mph
+        * ``precip_50_plus`` – precipitation probability at or above 50%
+        * ``temp_below_32`` – temperature below freezing (32°F)
+    """
+
+    out = df.copy()
+    if "wind_mph" in out.columns:
+        out["wind_15_plus"] = out["wind_mph"].ge(15)
+    else:
+        out["wind_15_plus"] = pd.NA
+
+    if "precip_prob_pct" in out.columns:
+        out["precip_50_plus"] = out["precip_prob_pct"].ge(50)
+    else:
+        out["precip_50_plus"] = pd.NA
+
+    if "temp_f" in out.columns:
+        out["temp_below_32"] = out["temp_f"].lt(32)
+    else:
+        out["temp_below_32"] = pd.NA
+
+    return out
+
+
+__all__ = ["om_forecast_near_kickoff", "open_meteo_for_game", "weather_flags"]


### PR DESCRIPTION
## Summary
- compute simple weather flags with `weather_flags` helper
- include new weather flags in feature expansion and game packet prompts
- surface weather flags in Q&A context builder

## Testing
- `python -m py_compile nfl_bot/weather.py nfl_bot/features.py nfl_bot/llm.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b779be43dc8330a1c7718e0e70a915