### PR TITLE
Add logging configuration and replace print statements with logger

### DIFF
--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,21 @@
+import logging
+import os
+
+
+def setup_logging(level: str | int | None = None) -> None:
+    """Configure root logging for the project.
+
+    Parameters
+    ----------
+    level: str | int | None
+        Desired logging level. If ``None``, the ``NFL_BOT_LOG_LEVEL`` environment
+        variable is consulted. Defaults to ``INFO`` when not provided.
+    """
+    if level is None:
+        level = os.getenv("NFL_BOT_LOG_LEVEL", "INFO")
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )

--- a/nfl_bot/features.py
+++ b/nfl_bot/features.py
@@ -5,6 +5,7 @@ from typing import Dict, Any
 import os
 import re
 import datetime as dt
+import logging
 
 import numpy as np
 import pandas as pd
@@ -15,6 +16,8 @@ from . import TEAM_CODE_TO_FULL
 from config import DATA_OUT
 from .data import _concat_per_year_safely
 from .weather import weather_flags
+
+logger = logging.getLogger(__name__)
 
 PREFERRED_BOOKS = (
     "fanduel",
@@ -350,7 +353,7 @@ def build_coach_ref_contexts(years_back: int = 4):
     try:
         officials = _concat_per_year_safely(nfl.import_officials, YEARS_TEND, "officials")
     except Exception as e:
-        print("officials: not available ->", e)
+        logger.warning("officials: not available -> %s", e)
         officials = pd.DataFrame(columns=["game_id"])
 
     def prep_pbp(df: pd.DataFrame) -> pd.DataFrame:
@@ -497,7 +500,7 @@ def build_coach_ref_contexts(years_back: int = 4):
     coach_ctx = coach_df.merge(tw_roll, on=["season", "week", "team"], how="left")
     coach_out = os.path.join(DATA_OUT, "coach_context.parquet")
     coach_ctx.to_parquet(coach_out, index=False)
-    print("[write]", coach_out, "rows=", len(coach_ctx))
+    logger.info("[write] %s rows=%s", coach_out, len(coach_ctx))
 
     if officials.empty:
         ref_ctx = pd.DataFrame()
@@ -514,7 +517,7 @@ def build_coach_ref_contexts(years_back: int = 4):
         ref_ctx = ref_games[ref_cols].copy()
     ref_out = os.path.join(DATA_OUT, "ref_context.parquet")
     ref_ctx.to_parquet(ref_out, index=False)
-    print("[write]", ref_out, "rows=", len(ref_ctx))
+    logger.info("[write] %s rows=%s", ref_out, len(ref_ctx))
 
     return {"coach_ctx": coach_ctx, "ref_ctx": ref_ctx, "coach_path": coach_out, "ref_path": ref_out}
 

--- a/nfl_bot/llm.py
+++ b/nfl_bot/llm.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Any, Optional
 import json
 import os
 import re
+import logging
 
 import pandas as pd
 import numpy as np
@@ -18,6 +19,8 @@ from .features import (
     receiver_vs_secondary,
     run_fit,
 )
+
+logger = logging.getLogger(__name__)
 
 client = OpenAI()
 
@@ -270,7 +273,7 @@ def llm_picks_via_responses(
     df = pd.DataFrame(all_picks)
     if debug:
         for k, snip in enumerate(raw_snips):
-            print(f"--- Chunk {k} ---\n{snip}\n")
+            logger.debug("--- Chunk %s ---\n%s\n", k, snip)
     if df.empty:
         return df
     order = ["game_id", "market", "selection", "confidence", "units", "edge_note"]


### PR DESCRIPTION
## Summary
- introduce `logging_config.setup_logging` to centralize logging setup
- use `logger` instead of `print` in data, features, LLM modules and main CLI
- add CLI flag and env var to control verbosity

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b77cd354908330b76c7353cd95268d