### PR TITLE
Add tests for core utilities and configure CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest
+      - run: pytest -q

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,106 @@
+import sys
+import pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+import pandas as pd
+
+
+@pytest.fixture
+def sample_schedule():
+    return pd.DataFrame(
+        {
+            "game_id": ["g1"],
+            "season": [2024],
+            "week": [1],
+            "home_team": ["BUF"],
+            "away_team": ["NYJ"],
+            "kickoff": [pd.Timestamp("2024-09-07T17:00:00Z")],
+        }
+    )
+
+
+@pytest.fixture
+def sample_odds_events():
+    return pd.DataFrame(
+        {
+            "event_id": ["evt1"],
+            "commence_time": ["2024-09-07T17:00:00Z"],
+            "home_team": ["Buffalo Bills"],
+            "away_team": ["New York Jets"],
+            "sport_key": ["americanfootball_nfl"],
+            "home_code": ["BUF"],
+            "away_code": ["NYJ"],
+        }
+    )
+
+
+@pytest.fixture
+def sample_odds_long():
+    return pd.DataFrame(
+        [
+            {
+                "event_id": "evt1",
+                "commence_time": "2024-09-07T17:00:00Z",
+                "home_team": "Buffalo Bills",
+                "away_team": "New York Jets",
+                "bookmaker_key": "fanduel",
+                "bookmaker": "FanDuel",
+                "last_update": "2024-09-01T00:00:00Z",
+                "market": "totals",
+                "name": "Over",
+                "price": -110,
+                "point": 44.5,
+            },
+            {
+                "event_id": "evt1",
+                "commence_time": "2024-09-07T17:00:00Z",
+                "home_team": "Buffalo Bills",
+                "away_team": "New York Jets",
+                "bookmaker_key": "fanduel",
+                "bookmaker": "FanDuel",
+                "last_update": "2024-09-01T00:00:00Z",
+                "market": "spreads",
+                "name": "Buffalo Bills",
+                "price": -110,
+                "point": -7.0,
+            },
+        ]
+    )
+
+
+@pytest.fixture
+def weather_by_game(sample_schedule):
+    return pd.DataFrame(
+        {
+            "game_id": sample_schedule["game_id"],
+            "home_team": sample_schedule["home_team"],
+            "kickoff": sample_schedule["kickoff"],
+            "weather": [
+                {
+                    "temp_f": 70,
+                    "wind_mph": 5,
+                    "precip_prob_pct": 10,
+                    "time_near_kickoff": "2024-09-07T17:00:00Z",
+                    "lat": 0,
+                    "lon": 0,
+                }
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def sample_weather_json():
+    return {
+        "hourly": {
+            "time": [
+                "2024-09-07T00:00",
+                "2024-09-07T01:00",
+                "2024-09-07T02:00",
+            ],
+            "temperature_2m": [70, 71, 72],
+            "wind_speed_10m": [5, 6, 7],
+            "precipitation_probability": [0, 10, 20],
+        }
+    }

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,80 @@
+import pandas as pd
+
+from nfl_bot.features import build_implied_totals
+
+
+def test_build_implied_totals_handles_missing_lines():
+    schedule = pd.DataFrame(
+        {
+            "game_id": ["g1", "g2"],
+            "season": [2024, 2024],
+            "week": [1, 1],
+            "home_team": ["BUF", "MIA"],
+            "away_team": ["NYJ", "NE"],
+            "kickoff": [
+                pd.Timestamp("2024-09-07T17:00:00Z"),
+                pd.Timestamp("2024-09-07T20:00:00Z"),
+            ],
+        }
+    )
+
+    odds_events = pd.DataFrame(
+        {
+            "event_id": ["evt1", "evt2"],
+            "commence_time": [
+                "2024-09-07T17:00:00Z",
+                "2024-09-07T20:00:00Z",
+            ],
+            "home_team": ["Buffalo Bills", "Miami Dolphins"],
+            "away_team": ["New York Jets", "New England Patriots"],
+            "home_code": ["BUF", "MIA"],
+            "away_code": ["NYJ", "NE"],
+        }
+    )
+
+    odds_long = pd.DataFrame(
+        [
+            {
+                "event_id": "evt1",
+                "commence_time": "2024-09-07T17:00:00Z",
+                "home_team": "Buffalo Bills",
+                "away_team": "New York Jets",
+                "bookmaker_key": "fanduel",
+                "bookmaker": "FanDuel",
+                "last_update": "2024-09-01T00:00:00Z",
+                "market": "totals",
+                "name": "Over",
+                "price": -110,
+                "point": 44.5,
+            },
+            {
+                "event_id": "evt2",
+                "commence_time": "2024-09-07T20:00:00Z",
+                "home_team": "Miami Dolphins",
+                "away_team": "New England Patriots",
+                "bookmaker_key": "fanduel",
+                "bookmaker": "FanDuel",
+                "last_update": "2024-09-01T00:00:00Z",
+                "market": "spreads",
+                "name": "Miami Dolphins",
+                "price": -110,
+                "point": -3.0,
+            },
+        ]
+    )
+
+    bundle = {
+        "schedule": schedule,
+        "odds_events": odds_events,
+        "odds_long": odds_long,
+    }
+
+    result = build_implied_totals(bundle)
+
+    g1 = result[result["game_id"] == "g1"].iloc[0]
+    assert pd.isna(g1["home_spread"])
+    assert pd.isna(g1["home_tt"]) and pd.isna(g1["away_tt"])
+
+    g2 = result[result["game_id"] == "g2"].iloc[0]
+    assert pd.isna(g2["total_line"])
+    assert pd.isna(g2["home_tt"]) and pd.isna(g2["away_tt"])

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,56 @@
+import os
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+import pandas as pd
+
+from nfl_bot.llm import build_game_packets
+
+
+def test_build_game_packets_merges_contexts(
+    sample_schedule,
+    sample_odds_events,
+    sample_odds_long,
+    weather_by_game,
+    monkeypatch,
+):
+    bundle = {
+        "schedule": sample_schedule,
+        "odds_events": sample_odds_events,
+        "odds_long": sample_odds_long,
+        "weather_by_game": weather_by_game,
+    }
+
+    monkeypatch.setattr("nfl_bot.llm.pressure_delta", lambda bundle: pd.DataFrame())
+    monkeypatch.setattr("nfl_bot.llm.receiver_vs_secondary", lambda bundle: pd.DataFrame())
+    monkeypatch.setattr("nfl_bot.llm.run_fit", lambda bundle: pd.DataFrame())
+
+    packets = build_game_packets(bundle)
+    assert isinstance(packets, list)
+    assert len(packets) == len(sample_schedule)
+    pkt = packets[0]
+    assert {
+        "game_id",
+        "season",
+        "week",
+        "kickoff",
+        "home",
+        "away",
+        "market",
+        "weather",
+        "referee",
+        "matchups",
+    } <= pkt.keys()
+    assert {
+        "total",
+        "home_spread",
+        "totals_book",
+        "spreads_book",
+    } <= pkt["market"].keys()
+    assert {
+        "temp_f",
+        "wind_mph",
+        "precip_prob_pct",
+        "wind_15_plus",
+        "precip_50_plus",
+        "temp_below_32",
+    } <= pkt["weather"].keys()

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+from nfl_bot.weather import om_forecast_near_kickoff
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+def test_om_forecast_near_kickoff_selects_nearest_hour(sample_weather_json, monkeypatch):
+    def fake_get(url, params=None, timeout=0):
+        return DummyResp(sample_weather_json)
+
+    monkeypatch.setattr("nfl_bot.weather.http.get", fake_get)
+    kickoff = pd.Timestamp("2024-09-07T01:20:00")
+    res = om_forecast_near_kickoff(0, 0, kickoff)
+    assert res["time_near_kickoff"] == "2024-09-07T01:00"
+    assert res["temp_f"] == 71
+    assert res["wind_mph"] == 6
+    assert res["precip_prob_pct"] == 10


### PR DESCRIPTION
## Summary
- add pytest fixtures for odds, schedule, and weather samples
- test implied totals, weather forecast selection, and game packet merge
- run tests in GitHub Actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77e5a4dbc83309ed32405aedbc7cf